### PR TITLE
fix(#25): group action updates so dependabot stops dropping them.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,11 @@ updates:
     directory: /
     schedule:
       interval: "monthly"
+    # The workflows use more actions than the default open-PR limit of 5, and
+    # unmerged PRs keep holding that quota, so the lowest-ranked updates were
+    # silently never proposed: setup-go sat on 6.1.0 for two whole cycles.
+    # Grouping makes the limit unreachable; the raised limit is belt and braces.
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
- The default open-pull-requests-limit of 5 while we currently use 7 actions
- Unmerged PRs keep holding that quota, so lower-ranked updates were never proposed:
- Grouping makes the limit unreachable.
- gomod retained although inert, only because envrun has no direct deps yet, but will help if it ever gets any.
- Tool deps (staticcheck) are covered by "go get -u tool" in update.yml.