### PR TITLE
feat(#41): publish signed binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,25 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') == false
     runs-on: ubuntu-latest
     steps:
-    - name: Harden the runner (Audit all outbound calls)
+    # Blocked rather than audited, because this job is exercised on every PR
+    # that touches it: a missing endpoint costs a red check here, where in the
+    # release job below it would cost a release. sum.golang.org and
+    # objects.githubusercontent.com are not in StepSecurity's observed baseline,
+    # which reflects a warm module cache; a cold one reaches both.
+    - name: Harden the runner (Block unexpected outbound calls)
       uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >
+          api.github.com:443
+          get.anchore.io:443
+          github.com:443
+          objects.githubusercontent.com:443
+          proxy.golang.org:443
+          raw.githubusercontent.com:443
+          release-assets.githubusercontent.com:443
+          sum.golang.org:443
+          toolbox-data.anchore.io:443
 
     # Full history: GoReleaser derives the version and the changelog from tags.
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,148 @@
+name: Release
+on:
+  push:
+    tags: [ 'v*' ]
+  # Snapshot only, so the pipeline can be debugged without a tag.
+  # The paths are the two files whose changes -- including Dependabot's action
+  # bumps -- can break the build or lose the version stamp.
+  pull_request:
+    paths:
+      - .goreleaser.yaml
+      - .github/workflows/release.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # A second job rather than a conditional on the one below:
+  # a snapshot needs none of the release job's write permissions,
+  # and granting them to a job that runs on pull_request would hand them
+  # to a same-repo branch that has passed no review yet.
+  snapshot:
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+      with:
+        egress-policy: audit
+
+    # Full history: GoReleaser derives the version and the changelog from tags.
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Set up Go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        go-version-file: go.mod
+
+    # GoReleaser shells out to syft by name for the SBOMs.
+    - name: Install syft
+      uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+    - name: Build a snapshot
+      uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+      with:
+        # An exact version, not the action's default "~> v2" range:
+        # a release must be built by the binary its config was verified against.
+        version-file: .tool-versions
+        args: release --snapshot --clean
+
+    # The artifact's only identity is the version Go writes into the build
+    # info from the VCS tag, so a build that dropped it would ship binaries
+    # nobody can tell apart. Checked here because this job runs on every
+    # change to the config or to the actions that produce them.
+    - name: Check the version stamp survived
+      run: |
+        bin=$(find dist -type f -name envrun -print -quit)
+        info=$(go version -m "$bin")
+        echo "$info" | grep -E '^[[:space:]]+mod[[:space:]]'
+        case "$info" in
+          *'(devel)'*)
+            echo "::error::the build lost the VCS version stamp"
+            exit 1
+            ;;
+          *'+dirty'*)
+            echo "::error::the build ran against a modified tree"
+            exit 1
+            ;;
+        esac
+
+  release:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write      # create the release and upload its assets
+      id-token: write      # the OIDC token Sigstore signs against
+      attestations: write
+      artifact-metadata: write
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Set up Go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        go-version-file: go.mod
+
+    - name: Install syft
+      uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+    - name: Build and publish the release
+      uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+      with:
+        # An exact version, not the action's default "~> v2" range:
+        # a release must be built by the binary its config was verified against.
+        version-file: .tool-versions
+        args: release --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Repeated from the snapshot job rather than shared: a release that lost
+    # the stamp must not publish, and the two jobs never run together.
+    - name: Check the version stamp survived
+      run: |
+        bin=$(find dist -type f -name envrun -print -quit)
+        info=$(go version -m "$bin")
+        echo "$info" | grep -E '^[[:space:]]+mod[[:space:]]'
+        case "$info" in
+          *'(devel)'*)
+            echo "::error::the build lost the VCS version stamp"
+            exit 1
+            ;;
+          *'+dirty'*)
+            echo "::error::the build ran against a modified tree"
+            exit 1
+            ;;
+        esac
+
+    # One attestation covering every artifact, keyed by the checksums file.
+    - name: Attest the released artifacts
+      id: attest
+      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+      with:
+        subject-checksums: dist/checksums.txt
+
+    # `gh attestation verify` finds the bundle through the API, but Scorecard's
+    # Signed-Releases check reads release *assets* and matches on the
+    # extension, so the same bundle has to be attached under a name it accepts.
+    - name: Publish the attestation as a release asset
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        TAG: ${{ github.ref_name }}
+      run: |
+        # Archive names use GoReleaser's .Version, which drops the leading v.
+        asset="envrun_${TAG#v}.sigstore.json"
+        cp "$BUNDLE" "$asset"
+        gh release upload "$TAG" "$asset"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,13 @@ jobs:
   # a snapshot needs none of the release job's write permissions,
   # and granting them to a job that runs on pull_request would hand them
   # to a same-repo branch that has passed no review yet.
+  #
+  # Both guards test the ref rather than the event, so that adding a trigger
+  # -- `branches: [main]`, say -- cannot turn a merge into a release: the
+  # tag-only filter on `push` would otherwise be the sole thing keeping
+  # `event_name == 'push'` equivalent to "on a tag", in another part of the file.
   snapshot:
-    if: github.event_name != 'push'
+    if: startsWith(github.ref, 'refs/tags/v') == false
     runs-on: ubuntu-latest
     steps:
     - name: Harden the runner (Audit all outbound calls)
@@ -72,7 +77,7 @@ jobs:
         esac
 
   release:
-    if: github.event_name == 'push'
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write      # create the release and upload its assets

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -45,6 +45,19 @@ jobs:
       - name: Tidy
         run: go mod tidy
 
+      # GoReleaser is pinned in .tool-versions, which neither `go get -u`
+      # above nor Dependabot's github-actions group can reach: one sees only
+      # go.mod, the other only `uses:` refs. This step is what keeps that pin
+      # moving with the rest.
+      - name: Update the pinned GoReleaser
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          latest=$(gh api repos/goreleaser/goreleaser/releases/latest -q .tag_name)
+          [ -n "$latest" ] || { echo "no GoReleaser release found"; exit 1; }
+          sed -i "s/^goreleaser .*/goreleaser ${latest#v}/" .tool-versions
+          grep '^goreleaser ' .tool-versions
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -71,7 +84,7 @@ jobs:
           commit-message: |
             Update package dependencies + tidy
 
-            Weekly update to the project's package dependencies initiated by an
+            Monthly update to the project's package dependencies initiated by an
             automatic GitHub Action running on cron. Keeps upgrades less of a
             monolithic task and lets security-related patches trickle in more
             quickly.

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@
 # Created by "make cover". Only its *.out contents match a rule below, so the
 # directory itself needs one: anything else written there would be committed.
 /coverage/
+# Created by "goreleaser release". Beyond not belonging in the tree, an
+# unignored dist/ would make every release build report itself "+dirty":
+# Go's VCS stamp counts untracked files, and that stamp is the artifact's
+# only version identity.
+/dist/
 
 # Binaries for programs and plugins
 *.exe

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,63 @@
+# Release build matrix for envrun.
+# Run by .github/workflows/release.yml on a pushed tag,
+# and in snapshot mode on any change to this file,
+# so the pipeline can be exercised without minting a tag: the module proxy caches immutably,
+# and a tag pushed to debug CI could never be taken back.
+version: 2
+
+before:
+  hooks:
+    - go mod verify
+
+builds:
+  - main: .
+    binary: envrun
+    env:
+      # The command links no C, and an explicit 0 keeps a runner with a C
+      # toolchain from producing a dynamically linked artifact.
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    # GoReleaser's default ldflags stamp -X main.version and three siblings.
+    # envrun declares none of them: since Go 1.24 `go build` writes the tag
+    # into the build info by itself, which `go version -m` already reads.
+    ldflags:
+      - -s -w
+    # Only the platforms that can start a process. js/wasm and wasip1/wasm
+    # compile but cannot exec (exec_other.go:31), so shipping them from a
+    # command runner would promise something the artifact cannot do.
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+archives:
+  - name_template: "envrun_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - README.md
+      - LICENSE
+      - SECURITY.md
+      - docs
+
+checksum:
+  name_template: checksums.txt
+
+# One SPDX document per archive, from syft, which the release workflow puts on
+# PATH. It reads the binary's own build graph, so it must report no
+# dependencies -- the claim docs/installing.md makes about go.mod's
+# staticcheck-only requires.
+sboms:
+  - artifacts: archive
+
+release:
+  prerelease: auto

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,6 @@
+# The GoReleaser that .github/workflows/release.yml builds with, in asdf/mise
+# format, which is the only shape goreleaser-action's version-file input reads.
+# It lives here rather than in the workflow's `with:` because Dependabot sees
+# `uses:` refs and go.mod, never an action input: .github/workflows/update.yml
+# is what moves this line.
+goreleaser 2.18.0

--- a/README.md
+++ b/README.md
@@ -32,7 +32,14 @@ see [Exit status and platform scope](docs/exit-status.md).
 
 ## Installing
 
-Pin the version in your project, then build the binary from that pin:
+**Without a Go toolchain**, download the archive for your platform from the
+[latest release](https://github.com/fgm/envrun/releases/latest), unpack it,
+and put `envrun` on your `$PATH`.
+Every release is built by GitHub Actions and carries a Sigstore attestation
+of the repository, workflow and commit it came from.
+
+**With one**, pin the version in your project and build the binary from that pin,
+so the version follows the project rather than the machine:
 
 ```console
 $ go get -tool github.com/fgm/envrun@latest
@@ -40,8 +47,9 @@ $ go build -o bin/ github.com/fgm/envrun
 ```
 
 Then run `bin/envrun <myprogram>`.
-`go tool` and `go install` work too, each at a cost in transparency or in pinning:
-see the [Installing](docs/installing.md) document.
+`go tool` and `go install` work too, each at a cost in transparency or in pinning.
+Verifying a download, and the full comparison, is in the
+[Installing](docs/installing.md) document.
 
 ## Running
 
@@ -80,7 +88,9 @@ The rest, and the Windows divergence, is in
 ## Dependencies
 
 None at build or run time: `envrun` uses only the standard library.
-The modules in `go.mod` belong to `staticcheck`, used for linting —
+The modules in `go.mod` belong to `staticcheck`, used for linting.
+Each release archive ships an SPDX SBOM built from the binary itself,
+so the claim is checkable without a toolchain —
 see the [Installing](docs/installing.md#dependencies) document.
 
 ## Related tools
@@ -90,7 +100,8 @@ The command runs exactly as if it had read the file itself —
 same process, same signals, same exit status, same terminal —
 and nothing in the file is ever expanded or executed,
 so a value cannot mean one thing to a shell and another to the program.
-No dependencies, standard library only, checkable with `go version -m`.
+No dependencies, standard library only,
+checkable with `go version -m` or with the SBOM shipped in every release.
 
 - **[godotenv](https://github.com/joho/godotenv)** is a library:
   the program does the loading, so it has to be Go, and it has to be changed.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,46 @@
 
 ## Supported Versions
 
-Fixes go into the latest tagged release only.
-Until 1.0 that means the newest `v0.x` tag:
-there are no maintenance branches, so an earlier tag is superseded, never patched.
+Fixes go into the latest release only.
+Until 1.0 that means the newest `v0.x` tag and the binaries published with it:
+there are no maintenance branches,
+so an earlier release is superseded, never patched.
 
-| Version           | Supported          |
-|-------------------|:------------------:|
-| latest `v0.x` tag | :white_check_mark: |
-| earlier tags      | :x:                |
-| `main` at HEAD    | :x:                |
+| Version               | Supported          |
+|-----------------------|:------------------:|
+| latest `v0.x` release | :white_check_mark: |
+| earlier releases      | :x:                |
+| `main` at HEAD        | :x:                |
+
+## Verifying a release
+
+Release binaries are built on GitHub Actions by
+[this repository's release workflow](https://github.com/fgm/envrun/actions/workflows/release.yml)
+and signed through [Sigstore](https://www.sigstore.dev)
+against that workflow's OIDC identity.
+
+**There is no signing key to obtain, and none to steal.**
+Signing uses a short-lived certificate bound to the workflow identity,
+rather than a long-lived private key,
+so no secret is held on the release machine or anywhere else.
+What the signature establishes is the repository, workflow and commit that produced the artifact,
+recorded in Sigstore's public transparency log.
+
+To verify a download, with the [GitHub CLI](https://cli.github.com):
+
+```console
+$ gh attestation verify envrun_0.3.0_linux_amd64.tar.gz --owner fgm
+```
+
+It fails if the archive was altered,
+or was not produced by this repository's workflow.
+
+`checksums.txt`, published beside the archives, is not a substitute:
+it detects a corrupted download but not a substituted one,
+because it is a list, and the attestation is what says who wrote the list.
+
+Each release also carries one SPDX SBOM per archive,
+generated from the binary's own build graph rather than from `go.mod`.
 
 
 ## Reporting a Vulnerability

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -5,7 +5,56 @@ The route decides whether the transparency `envrun` offers is felt at all:
 where a built binary does not.
 See [Exit status and platform scope](exit-status.md) for what that costs.
 
-## The recommended route
+Two routes avoid that process entirely, and they serve different readers:
+**download a released binary** if you have no Go toolchain,
+**build one from a pin** if you have one and want the version tied to a project.
+
+## Downloading a released binary
+
+Take the archive for your platform from the
+[latest release](https://github.com/fgm/envrun/releases/latest),
+unpack it, and put `envrun` somewhere on your `$PATH`.
+
+Six platforms are published: Linux, macOS and Windows, each on `amd64` and `arm64`.
+The WebAssembly ports compile but cannot start a process, so no artifact ships for them.
+
+Each release carries, beside the archives:
+
+- `checksums.txt`, a SHA-256 over every archive;
+- one SPDX SBOM per archive, from [syft](https://github.com/anchore/syft);
+- `envrun_<version>.sigstore.json`, the signed attestation of where the
+  archives were built.
+
+Nothing here is tied to a project, so a `go.mod` bump will not update it.
+That is the trade against the next route.
+
+## Verifying what you downloaded
+
+The archives are signed through [Sigstore](https://www.sigstore.dev)
+against GitHub's OIDC identity,
+so there is no public key to fetch and no private key held anywhere.
+The attestation names the repository, the workflow and the commit that produced the artifact.
+
+With the [GitHub CLI](https://cli.github.com):
+
+```console
+$ gh attestation verify envrun_0.3.0_linux_amd64.tar.gz --owner fgm
+```
+
+It fails if the archive was modified, or was not built by this repository's
+release workflow.
+
+Without it, `checksums.txt` still catches a corrupted download
+(`shasum -a 256 -c` on macOS):
+
+```console
+$ sha256sum --check --ignore-missing checksums.txt
+```
+
+A checksum proves only that the file matches the list, and says nothing about
+who wrote the list. The attestation is what answers that.
+
+## Building from a pin
 
 Pin the version in your project, then build the binary from that pin:
 
@@ -46,6 +95,9 @@ Both work, and both cost something the recipe above does not:
   installs that module's pinned version, which fixes the pin but not the sharing.
 - **`go run`** interposes and does not forward `SIGTERM` at all.
 
+A download shares `go install`'s weakness — nothing re-checks it — and avoids
+its sharing problem, since you decide where the binary lands.
+
 ## Dependencies
 
 `envrun` has none at build or run time: it uses only the standard library.
@@ -54,13 +106,22 @@ which lists one `dep` line per linked module:
 
 ```console
 $ go version -m bin/envrun
-bin/envrun: go1.26.7
+bin/envrun: go1.27.0
 	path	github.com/fgm/envrun
-	mod	github.com/fgm/envrun	v0.0.0-...
+	mod	github.com/fgm/envrun	v0.2.0-...
 	build	...
 ```
 
 No `dep` lines means no dependencies.
+
+The same command identifies a downloaded binary: since Go 1.24 the `mod` line
+carries the tag it was built from, so a renamed or relocated artifact still
+says which release it is.
+
+Without a toolchain, the SBOM published beside each archive answers both questions instead.
+It is generated from the binary's own build graph rather than from `go.mod`,
+so its only entries are `envrun` itself, the Go standard library and the archive:
+no third-party package appears.
 
 The modules in `go.mod` belong to `staticcheck`, required by the `tool`
 directive for linting. They are not linked into the command, but GitHub's


### PR DESCRIPTION
Closes #41.

A pushed tag builds six exec-capable targets through GoReleaser, attaches their checksums and one SPDX SBOM per archive, and signs the set through Sigstore against the workflow's OIDC identity. A `pull_request` touching either release file builds a snapshot instead, so the pipeline is debuggable without minting a version the module proxy would cache forever.

**This PR publishes no release.** The pipeline lands first, and the first real tag is the one carrying #45 and #46 — a small payload, so the pipeline's first live run is not the run somebody is waiting on.

## Two premises in the issue had expired

- **`actions/attest-build-provenance` is superseded.** It is now a wrapper; new implementations use `actions/attest`, whose `subject-checksums` input takes `checksums.txt` directly.
- **`slsa-github-generator` is unmaintained**, and points at GitHub artifact attestations instead.

And one that was never in it: **attestation alone does not satisfy Scorecard.** `Signed-Releases` reads release *assets* and matches on the extension, so the bundle is attached as `*.sigstore.json` rather than left in the attestations API. That scores 8; only `.intoto.jsonl` reaches 10.

## Decisions

- **No version variable.** Since Go 1.24 the VCS tag is stamped into the build info, so the ldflags are `-s -w` only. Both jobs fail if a build loses the stamp or ran against a modified tree.
- **`/dist/` is ignored for correctness, not tidiness** — the stamp counts untracked files, so an unignored `dist/` would mark every release `+dirty`.
- **Six targets, not the five verified so far.** `js/wasm` and `wasip1/wasm` compile but cannot exec (`exec_other.go:31`), so they stay build checks; `linux/arm64`, `darwin/amd64` and `windows/arm64` cost only build seconds.
- **GoReleaser pinned in `.tool-versions`**, not the action's default `~> v2` range, with `update.yml` moving the pin: Dependabot sees `uses:` refs and `go.mod`, never an action input.
- **No `tool` directive.** It would cost 330 require lines for GoReleaser and 285 for syft, against the six that keep `docs/installing.md`'s no-dependencies claim checkable at a glance. Syft needs none anyway — the pinned `sbom-action` SHA already fixes it at v1.42.3.
- **No `-version` flag**, deferred: it is a printer over `debug.ReadBuildInfo()`, independent of this pipeline, and #46 is already inside `parseArgs`.

## Verified

CI: the `snapshot` job passes and `release` skips, and the stamp check reports `mod github.com/fgm/envrun v0.2.1-0.20260826145158-4dc156fc1b67` — the stamp survives GoReleaser on a real runner, with no `+dirty`, and the pseudo-version is correct for a commit ahead of `v0.2.0`.

Locally: `goreleaser check`; a full `release --snapshot` producing 6 archives, 6 SBOMs and `checksums.txt`; zero `dep` lines in the binary; a clean-clone build at `v0.2.0` stamping the plain tag; the updater's `sed` against a real API response. All against 2.18.0, the pinned version.

Corrected by those runs rather than assumed: `docs/**/*` silently excluded every top-level `docs/*.md`, and the SBOM lists `envrun`, `stdlib` and the archive rather than "the module and nothing else".

## Needs a tag

The attestation and the `*.sigstore.json` upload need the OIDC token, which only the tag-triggered job has, and Scorecard's `Signed-Releases` only moves once a Release exists. Both get their first exercise on the #45/#46 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
