### PR TITLE
docs(#45): require the environment file, named or defaulted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,14 @@ Verifying a download, and the full comparison, is in the
 
 ## Running
 
-- `envrun foo`: run `foo` with the environment defaults loaded from `.env` if it exists,
-  or fail if it cannot be read.
+- `envrun foo`: run `foo` with the environment defaults loaded from `.env`,
+  or fail if it is missing or cannot be read.
 - `envrun -f other.env env`: run the `env` command with the defaults loaded from `other.env`.
+
+The file is required either way.
+A run with no defaults to add is a run that does not need `envrun`,
+so a missing file is a failure rather than a silent pass-through:
+configuration that was meant to be there is worth stopping for.
 
 `envrun` reads the file, it never sources it — no expansion, no execution,
 so `DSN=postgres://${INSTANCE}/db` reaches the command exactly as written.

--- a/doc.go
+++ b/doc.go
@@ -10,6 +10,8 @@
 //	-f file
 //		Read the environment from file
 //		instead of .env in the working directory.
+//		The file must exist, named or defaulted:
+//		a run with no defaults to add does not need envrun.
 //
 // The file is read, never sourced — no expansion and no execution — so a value
 // reaches the command exactly as written. Its variables are merged under the


### PR DESCRIPTION
README.md promised defaults "loaded from .env if it exists", which the code has never done: a missing file is fatal whether -f named it or envrun assumed it.

Closes #45 