### PR TITLE
fix(#46): -h is not a failure, and a rejected flag is reported once

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,17 +76,19 @@ so the demo cannot drift from the documented behaviour.
 ## Exit status
 
 The command reports for itself.
+Apart from `-h`, which prints usage on standard output and exits `0`,
 `envrun` has statuses only for its own failures, before the command starts,
 following the convention of coreutils `env`, `timeout` and `nohup`:
 
 - `125`: `envrun` itself failed — the environment file could not be read,
-  or no command was given
+  a flag was not understood, or no command was given
 - `126`: the command exists but could not be executed
 - `127`: the command could not be found
 
 A command exiting `125` itself is indistinguishable by status alone,
 so standard error carries the answer:
 every failure of `envrun`'s own is prefixed `envrun failed:`.
+A `0` from `-h` carries no such line, having failed at nothing.
 The rest, and the Windows divergence, is in
 [Exit status and platform scope](docs/exit-status.md).
 

--- a/doc.go
+++ b/doc.go
@@ -4,6 +4,7 @@
 // Usage:
 //
 //	envrun [-f file] command [argument ...]
+//	envrun -h
 //
 // The flags are:
 //
@@ -12,6 +13,10 @@
 //		instead of .env in the working directory.
 //		The file must exist, named or defaulted:
 //		a run with no defaults to add does not need envrun.
+//
+//	-h, -help
+//		Print the usage message on standard output and exit 0,
+//		without reading the environment or running a command.
 //
 // The file is read, never sourced — no expansion and no execution — so a value
 // reaches the command exactly as written. Its variables are merged under the
@@ -30,6 +35,7 @@
 //
 // Statuses 125, 126 and 127 report envrun's own failures before the command
 // starts, following the convention of coreutils env, timeout and nohup.
+// They are the only statuses envrun reports for itself, -h aside.
 // A command exiting 125 itself stays distinguishable,
 // because envrun names itself on standard error whenever one of these is its own.
 // See docs/exit-status.md.

--- a/docs/adr/002-splitting-the-command-from-the-library.md
+++ b/docs/adr/002-splitting-the-command-from-the-library.md
@@ -262,6 +262,12 @@ It reports through two package-level helpers, `fail(err)` and `note(format, args
 writing to `log`'s default logger with the flags cleared.
 Two shapes, one destination, no levels.
 
+**That covers diagnostics, not everything envrun writes.**
+Output the user *asked for* — `-h`'s usage today, `-version` later —
+goes to standard output and carries no prefix,
+because it is the command's product rather than a report about it,
+and a caller redirecting it wants it apart from the diagnostics.
+
 **The `log` package with its flags cleared, not `slog`.**
 That is what is already in place, and what stays:
 the prefix lives in the format string, the destination is `log`'s own default,
@@ -463,6 +469,8 @@ it may name the variable and the lines, never either value.
 - **The CLI keeps `log`**, flags cleared, through the two helpers it already has,
   emitting plain prefixed lines on standard error rather than structured records.
   `slog` is declined and the package-level logger kept.
+  Amended by #46: that governs diagnostics, and requested output such as `-h`'s
+  usage goes to standard output instead.
   See *Who prints, and how*.
 
 - **Duplicate detection lands with issue #3**, which already asks for it:

--- a/docs/exit-status.md
+++ b/docs/exit-status.md
@@ -11,12 +11,14 @@ On \*nix there is no `envrun` left once it starts,
 so its status, including death by a signal,
 reaches the caller unchanged and untranslated.
 
+Apart from `-h`, which prints usage on standard output and exits `0`
+without reading the environment or running anything,
 `envrun` has statuses only for its own failures, before the command starts.
 They follow the convention used by coreutils `env`, `timeout` and `nohup`,
 which keeps them out of the range a command is likely to use:
 
 - `125`: `envrun` itself failed — the environment file could not be read,
-  or no command was given
+  a flag was not understood, or no command was given
 - `126`: the command exists but could not be executed
 - `127`: the command could not be found
 
@@ -30,8 +32,10 @@ because every failure of `envrun`'s own names the process that failed:
 envrun failed: reading .env: open .env: no such file or directory
 ```
 
-That line is present exactly when the status is `envrun`'s;
-where it is absent, the status belongs to the command.
+Among `125`, `126` and `127` that line is present exactly when the status is
+`envrun`'s; where it is absent, the status belongs to the command.
+The qualifier matters because `-h` is envrun's own `0` and carries no such line:
+it did not fail, and nothing ran.
 
 `envrun` starts what the operating system can start, and no more:
 a file with the execute bit but no shebang and no loadable format reports `126`,

--- a/env/env.go
+++ b/env/env.go
@@ -13,6 +13,9 @@ import (
 )
 
 const (
+	// AppName is the name of the application, regardless of its invocation.
+	AppName = "envrun"
+
 	// commentRxS matches comment lines.
 	commentRxS = `^[\s]*#`
 	// nameRxS is much tighter than Posix, which accepts anything but NUL and '=',

--- a/env/example_test.go
+++ b/env/example_test.go
@@ -21,7 +21,7 @@ import (
 // is also compiled as a standalone program — by pkg.go.dev's Run button, say —
 // where a relative path would resolve against somewhere else entirely.
 func writeEnv(body string) (path string, remove func()) {
-	dir, err := os.MkdirTemp("", "envrun")
+	dir, err := os.MkdirTemp("", env.AppName)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	iofs "io/fs"
 	"log"
 	"os"
@@ -18,20 +19,72 @@ import (
 //
 // It resolves nothing and opens nothing: finding the file is env.Load's job,
 // and -f names the one candidate it is to consider.
-func parseArgs(args []string) (string, []string, error) {
+//
+// stdW is used by -h, errW by the error paths.
+func parseArgs(args []string, stdW, errW io.Writer) (string, []string, error) {
 	if len(args) < 2 {
 		return "", nil, errors.New("need at least a command to run")
 	}
-	fs := flag.NewFlagSet(args[0], flag.ContinueOnError)
+
+	// The set is named for the command rather than for args[0],
+	// so usage carries a stable name instead of the path the binary was
+	// reached through, which under `go run` is a build-cache directory.
+	fs := flag.NewFlagSet(env.AppName, flag.ContinueOnError)
+	// Discarded so that flag's own reporting does not land beside envrun's.
+	// It reports a rejected flag and returns the error, where envrun needs the
+	// line attributed; the message survives in the error, and is written below.
+	fs.SetOutput(io.Discard)
 	inName := fs.String("f", env.DefaultPath, "The file from which to read the environment variables")
-	if err := fs.Parse(args[1:]); err != nil {
-		return "", nil, fmt.Errorf("parsing flags: %w", err)
+
+	// Declared rather than left to flag.
+	// Declaring keeps flag from writing usage of its own, which it would send to one destination,
+	// for both a help request and a parse failure — and those need different ones.
+	showHelp := fs.Bool("h", false, "Print this message on standard output and exit")
+	fs.BoolVar(showHelp, "help", false, "Alias for -h")
+
+	// Prepend to flag's own rendering rather than replacing it:
+	// PrintDefaults cannot know about the command and arguments.
+	fs.Usage = func() {
+		fmt.Fprint(fs.Output(),
+			"Usage: envrun [-f file] command [argument ...]\n"+
+				"       envrun -h\n\nThe flags are:\n")
+		fs.PrintDefaults()
 	}
+
+	if err := fs.Parse(args[1:]); err != nil {
+		// Reported here rather than by realMain, because usage follows the
+		// message and only this function holds a set that can render it.
+		fail(fmt.Errorf("parsing flags: %w", err))
+		fs.SetOutput(errW)
+		fs.Usage()
+		return "", nil, errReported
+	}
+
+	// An exclusive flag says what envrun does instead of running a command,
+	// so it resolves before the operand check below,
+	// and before realMain reads the environment: neither applies to it.
+	//
+	// -h dominates: where it appears, every other flag and the operand are
+	// ignored, which is what sort, curl and python3 do and what a caller
+	// asking what this program is will least be surprised by.
+	if *showHelp {
+		fs.SetOutput(stdW)
+		fs.Usage()
+		return "", nil, flag.ErrHelp
+	}
+
 	if len(fs.Args()) == 0 {
 		return "", nil, errors.New("no command to run")
 	}
 	return *inName, fs.Args(), nil
 }
+
+// errReported marks a failure whose message has already reached the caller,
+// so realMain returns its status without saying it a second time.
+//
+// Named for the property rather than the case: flag reports a rejected command
+// line itself, and anything else that reports before returning can reuse this.
+var errReported = errors.New("already reported")
 
 // exitStatus classifies a failure of envrun's own into the status the README documents.
 //
@@ -56,6 +109,13 @@ func exitStatus(err error) int {
 	}
 }
 
+// A line starting with failPrefix means the status is envrun's; notePrefix means it is not.
+// docs/exit-status.md builds attribution on the difference.
+const (
+	failPrefix = env.AppName + " failed: "
+	notePrefix = env.AppName + ": "
+)
+
 // fail reports a failure of envrun's own, naming envrun as the process that failed.
 //
 // Every such line begins with the same three words,
@@ -68,7 +128,7 @@ func exitStatus(err error) int {
 // so the words are written in one place rather than at each call site,
 // where a message would eventually be phrased differently.
 func fail(err error) {
-	log.Printf("envrun failed: %v", err)
+	log.Printf(failPrefix+"%v", err)
 }
 
 // note reports something envrun saw without failing at it.
@@ -79,7 +139,7 @@ func fail(err error) {
 // It still names envrun,
 // since nothing else on standard error should be taken for the command's own output.
 func note(format string, args ...any) {
-	log.Printf("envrun: "+format, args...)
+	log.Printf(notePrefix+format, args...)
 }
 
 // reportNotes prints the non-fatal findings a [env.Result] carries.
@@ -104,8 +164,14 @@ func reportNotes(notes []env.Note) {
 // env.Load hands back what it saw, and this is the only party that knows the
 // output contract the README documents. See ADR-002.
 func realMain(args []string) int {
-	path, toRun, err := parseArgs(args)
-	if err != nil {
+	path, toRun, err := parseArgs(args, os.Stdout, os.Stderr)
+	switch {
+	// Help is not a failure: it wrote what was asked for and nothing ran.
+	case errors.Is(err, flag.ErrHelp):
+		return 0
+	case errors.Is(err, errReported):
+		return ExitEnvrun
+	case err != nil:
 		fail(err)
 		return ExitEnvrun
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"io/fs"
@@ -46,7 +47,7 @@ func TestMain(m *testing.M) {
 		helperReport(strconv.Itoa(os.Getpid()))
 	case "cat":
 		if _, err := io.Copy(os.Stdout, os.Stdin); err != nil {
-			fmt.Fprintln(os.Stderr, "helper process:", err)
+			_, _ = fmt.Fprintln(os.Stderr, "helper process:", err)
 			os.Exit(1)
 		}
 		os.Exit(0)
@@ -61,7 +62,7 @@ func TestMain(m *testing.M) {
 // helperReport writes the one fact the helper was asked for, and ends the process.
 func helperReport(s string) {
 	if err := os.WriteFile(os.Getenv(outVar), []byte(s), 0o600); err != nil {
-		fmt.Fprintln(os.Stderr, "helper process:", err)
+		_, _ = fmt.Fprintln(os.Stderr, "helper process:", err)
 		os.Exit(1)
 	}
 	os.Exit(0)
@@ -104,13 +105,34 @@ func shell() (string, string) {
 	return "sh", "-c"
 }
 
-// failPrefix is what fail() writes,
-// and what the README tells a caller to look for
-// when a 125, 126 or 127 could have come from either envrun or the command.
-// Asserted from both sides —
-// present for every own failure, absent whenever the command ran —
-// since a rule documented as exact is worth nothing if only half of it is checked.
-const failPrefix = "envrun failed: "
+// TestPrefixesMatchTheDocumentation reads the documents that quote the prefixes.
+//
+// They carry the literals rather than sharing the constants, so a prefix changed
+// here without changing them there leaves the attribution rule documented wrong.
+func TestPrefixesMatchTheDocumentation(t *testing.T) {
+	tests := []struct {
+		path   string
+		prefix string
+	}{
+		{path: filepath.Join("docs", "exit-status.md"), prefix: failPrefix},
+		{path: filepath.Join("docs", "exit-status.md"), prefix: notePrefix},
+		{path: "README.md", prefix: failPrefix},
+	}
+
+	for _, test := range tests {
+		t.Run(test.path+" "+strings.TrimSpace(test.prefix), func(t *testing.T) {
+			doc, err := os.ReadFile(test.path)
+			if err != nil {
+				t.Fatalf("reading the documentation: %v", err)
+			}
+			// Trimmed: prose quotes the token, not the separating space.
+			quoted := strings.TrimSpace(test.prefix)
+			if !strings.Contains(string(doc), quoted) {
+				t.Errorf("%s does not quote %q", test.path, quoted)
+			}
+		})
+	}
+}
 
 // TestDiagnosticsNameEnvrun states the attribution rule at the level it is written.
 //
@@ -138,7 +160,7 @@ func TestDiagnosticsNameEnvrun(t *testing.T) {
 	buf.Reset()
 	note("%s exited with status %d", "sh", 42)
 	actual := buf.String()
-	if expected := "envrun: sh exited with status 42\n"; actual != expected {
+	if expected := notePrefix + "sh exited with status 42\n"; actual != expected {
 		t.Errorf("note() wrote %q, expected %q", actual, expected)
 	}
 	// The load-bearing half:
@@ -277,7 +299,7 @@ func TestRealMainOwnFailures(t *testing.T) {
 			log.SetOutput(&stderr)
 			defer log.SetOutput(os.Stderr)
 
-			args := append([]string{"envrun", "-f", test.envFile}, test.command...)
+			args := append([]string{env.AppName, "-f", test.envFile}, test.command...)
 			if actual := realMain(args); actual != test.expected {
 				t.Errorf("realMain() = %d, expected %d", actual, test.expected)
 			}
@@ -302,11 +324,120 @@ func TestRealMainNeedsSomethingToRun(t *testing.T) {
 	log.SetOutput(&stderr)
 	defer log.SetOutput(os.Stderr)
 
-	if actual := realMain([]string{"envrun"}); actual != ExitEnvrun {
+	if actual := realMain([]string{env.AppName}); actual != ExitEnvrun {
 		t.Errorf("realMain() = %d, expected %d", actual, ExitEnvrun)
 	}
 	if !strings.Contains(stderr.String(), failPrefix) {
 		t.Errorf("stderr does not attribute the failure to envrun: %q", stderr.String())
+	}
+}
+
+// TestHelpWritesUsage covers what -h renders.
+//
+// In process, because parseArgs takes the destination as a parameter:
+// the stream it reaches on a real command line is what the subprocess case below proves.
+func TestHelpWritesUsage(t *testing.T) {
+	var out bytes.Buffer
+	_, _, err := parseArgs([]string{env.AppName, "-h"}, &out, io.Discard)
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Errorf("parseArgs() error = %v, expected it to wrap flag.ErrHelp", err)
+	}
+
+	// The synopsis is the half flag cannot render, PrintDefaults knowing
+	// nothing of the operand; the flag lines are the half it does.
+	for _, want := range []string{
+		"Usage: envrun [-f file] command [argument ...]",
+		"-f string",
+		"-help",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("usage does not mention %q: %q", want, out.String())
+		}
+	}
+}
+
+// TestRejectedFlagIsReportedOnce covers the other half of issue #46:
+// an unknown flag produced three outputs, two of them flag's own.
+//
+// A subprocess, because flag writes to os.Stderr where fail writes through log:
+// in process those are two destinations, and a count in either sees one copy
+// whether or not the other exists.
+func TestRejectedFlagIsReportedOnce(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("locating the test binary: %v", err)
+	}
+
+	cmd := exec.Command(exe, "-nosuchflag", "true")
+	cmd.Env = append(os.Environ(), mainVar+"=1")
+	cmd.Dir = t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil && cmd.ProcessState == nil {
+		t.Fatalf("failed running envrun: %v", err)
+	}
+	if actual := cmd.ProcessState.ExitCode(); actual != ExitEnvrun {
+		t.Errorf("exit status = %d, expected %d", actual, ExitEnvrun)
+	}
+
+	got := stderr.String()
+	if n := strings.Count(got, "not defined: -nosuchflag"); n != 1 {
+		t.Errorf("the flag is named %d times, expected 1: %q", n, got)
+	}
+	if !strings.Contains(got, failPrefix) {
+		t.Errorf("the failure is not attributed to envrun: %q", got)
+	}
+	// Usage after the message, which is why parseArgs reports and realMain does not.
+	if i, j := strings.Index(got, failPrefix), strings.Index(got, "Usage: envrun"); j < i {
+		t.Errorf("usage precedes the failure it explains: %q", got)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("a rejected flag wrote to standard output: %q", stdout.String())
+	}
+}
+
+// TestHelpIsNotAFailure covers the whole of issue #46's first half:
+// help goes to standard output, reports 0, and says nothing on standard error.
+//
+// A subprocess, because the streams are the point:
+// in process the writer is a parameter and proves nothing about os.Stdout.
+// The working directory has no .env, which a missing one being fatal since #45
+// turns into a real assertion: an exclusive flag reaches neither the operand
+// check nor env.Load.
+func TestHelpIsNotAFailure(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("locating the test binary: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		flag string
+	}{
+		{name: "-h", flag: "-h"},
+		{name: "-help", flag: "-help"},
+		{name: "--help", flag: "--help"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := exec.Command(exe, test.flag)
+			cmd.Env = append(os.Environ(), mainVar+"=1")
+			cmd.Dir = t.TempDir()
+
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout, cmd.Stderr = &stdout, &stderr
+			if err := cmd.Run(); err != nil {
+				t.Errorf("envrun %s = %v, expected it to succeed", test.flag, err)
+			}
+			if !strings.Contains(stdout.String(), "Usage: envrun") {
+				t.Errorf("standard output carries no usage: %q", stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Errorf("standard error is not empty: %q", stderr.String())
+			}
+		})
 	}
 }
 
@@ -393,7 +524,7 @@ func TestReportNotes(t *testing.T) {
 	reportNotes([]env.Note{env.CloseError{Err: cause}})
 
 	// A note, not a failure: envrun did not fail, so the line must not say so.
-	expected := "envrun: could not close the environment file: close x.env: permission denied\n"
+	expected := notePrefix + "could not close the environment file: close x.env: permission denied\n"
 	if actual := buf.String(); actual != expected {
 		t.Errorf("reportNotes() wrote %q, expected %q", actual, expected)
 	}

--- a/main_unix_test.go
+++ b/main_unix_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/fgm/envrun/env"
 )
 
 // TestExecKeepsThePID covers the process replacement itself,
@@ -155,7 +157,7 @@ func TestRealMainErrnoClassification(t *testing.T) {
 			log.SetOutput(&stderr)
 			defer log.SetOutput(os.Stderr)
 
-			if actual := realMain([]string{"envrun", "-f", valid, test.command(t)}); actual != test.expected {
+			if actual := realMain([]string{env.AppName, "-f", valid, test.command(t)}); actual != test.expected {
 				t.Errorf("realMain() = %d, expected %d", actual, test.expected)
 			}
 			// Asserted rather than merely swallowed: muting the line without


### PR DESCRIPTION
Closes #46. Both symptoms, one commit.

**`envrun -h`** printed usage on standard error and exited 125. It now prints usage on standard output and exits 0, reading no environment file and running nothing.

**An unknown flag** produced three outputs — `flag`'s message, `flag`'s usage block, then envrun's attributed duplicate. It now produces one attributed line followed by usage.

## Not the fix the issue proposed

The issue expected `-h` to arrive as an error needing "a sentinel error or a third return value". envrun **declares `-h` and `-help`** instead: `flag`'s help handling fires only for a name no flag defines, so declaring them means it writes nothing, returns nothing, and the choice of stream is envrun's.

The duplication was **propagation**, not routing. `flag` with `ContinueOnError` reports the error itself and returns it so the caller can stop; envrun treated the return as unreported. Its output is discarded and `parseArgs` reports instead — it holds the set, so it is the only place that can put usage *after* the message.

## Decisions

- `-h` dominates: other flags and the operand are ignored, as `sort`, `curl` and `python3` do. A `-version` test must sit below the `-h` one, or the dominance inverts invisibly.
- The attribution contract is untouched — 125 still carries `envrun failed:` — so `docs/exit-status.md` needed only a qualifier saying `-h`'s 0 is outside the rule.
- ADR-002 amended: `fail`/`note` stay the only diagnostic channel on stderr; output the user asked for goes to stdout.

## Tests

The old unknown-flag case could not see the duplication: `flag` writes to `os.Stderr` where `fail` goes through `log`, so an in-process count in either buffer sees one copy regardless. The replacement is a subprocess with a buffered `cmd.Stderr`, checked by mutation to fail when the discard is removed.

`TestPrefixesMatchTheDocumentation` reads `docs/exit-status.md` and `README.md` and asserts they quote the prefixes.

#45 shipped as docs only, so this is the change `v0.3.0` carries — and its tag is the release pipeline's first live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
